### PR TITLE
Add k8s documentation

### DIFF
--- a/manifests/examples/pando-test-periodic-deployment.yaml
+++ b/manifests/examples/pando-test-periodic-deployment.yaml
@@ -8,7 +8,7 @@ spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment
-    name: test-periodic
+    name: pando-test-periodic
   resourcePolicy:
     containerPolicies:
       - containerName: '*'


### PR DESCRIPTION
I have added k8s documentation and tested this in a local 10-node Kubernetes cluster environment and all works as expected. 

Summary of changes. 

- Edit the README.md file and add Kubernetes-specific implementation. 
- Edit manifests/examples/pando-test-periodic-deployment.yaml:11 and replace test-periodic with pando-test-periodic